### PR TITLE
Added Boolean operators and,or for binary expressions

### DIFF
--- a/MicroPascal/Interpreter.cpp
+++ b/MicroPascal/Interpreter.cpp
@@ -66,6 +66,20 @@ Literal Interpreter::Visit(BinaryExpr& binExpr)
 		}
 	}
 
+	//boolean operators and,or
+	if (IsBool(left_value) && IsBool(right_value)) // (in)equality only for same types
+	{
+		switch (binExpr.op.type)
+		{
+		case TokenType::AND:
+			return std::get<bool>(left_value) && std::get<bool>(right_value);
+		case TokenType::OR:
+			return std::get<bool>(left_value) || std::get<bool>(right_value);
+		default:
+			break;
+		}
+	}
+
 	throw Error(binExpr.op.line_num, "types incompatible with given operator.");
 }
 


### PR DESCRIPTION
Description:
Hey, cool project,
 Really interesting and useful!
Just found the implementation for boolean operators on Binary expressions missing
example:
    { IF }
    if (p = true) and (i=50)
    then
        writeln('p is true')
gives an error - 
[Line: 14] Error: types incompatible with given operator.

after fixing:
o/p : p is true
Testing:
 Tested on local device